### PR TITLE
Update guide.html (fix typo)

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -192,7 +192,7 @@
 
 	    			<p>Now you will rent a machine, or a virtual part of a machine, somewhere in &ldquo;the cloud.&rdquo; We&rsquo;ll call this machine your box. We recommend going over to <a href="https://www.linode.com/">Linode</a>, <a href="https://www.1and1.com/">1&amp;1</a>, or <a href="https://rimuhosting.com/order/v2orderstart.jsp">Rimuhosting.com</a>. (Most cloud providers will do, but not Amazon Web Services because its network is often blocked to prevent users from sending spam.)</p>
 
-					<p><strong>You must choose the <code>Ubuntu 18.04 x64 (server edition)</code> operating system and a machine with at least 512 MB of RAM.</strong> This setup currently costs around $5/month, depending on which provider you choose. We recommend you to use a box with 1 GB of RAM which costs around $10/month.</p>
+					<p><strong>You must choose the <code>Ubuntu 22.04 x64 (server edition)</code> operating system and a machine with at least 512 MB of RAM.</strong> This setup currently costs around $5/month, depending on which provider you choose. We recommend you to use a box with 1 GB of RAM which costs around $10/month.</p>
 
 				<p>If you choose Digital Ocean, your machine is called a &ldquo;droplet&rdquo; and you <strong>must</strong> name your droplet the same as its hostname.</p>
 


### PR DESCRIPTION
Fix typo in setup guide referring to Ubuntu 18.04 rather than 22.04.